### PR TITLE
drivers: sensor: bq274xx: allow PM_DEVICE when int_gpios not in use

### DIFF
--- a/dts/bindings/sensor/ti,bq274xx.yaml
+++ b/dts/bindings/sensor/ti,bq274xx.yaml
@@ -37,7 +37,8 @@ properties:
       description: |
         The INT signal defaults to active low open drain, so requires a
         pull-up on the board. By default it acts as an output and signals
-        specific events happening (e.g. change in State of Charge). While in
+        specific events happening (e.g. change in State of Charge).
+        Note this pin is required for this sensor's power management APIs: in
         shutdown mode it acts as an input and toggling it will make the sensor
         exit the mode.
 


### PR DESCRIPTION
A user of the driver may be using CONFIG_PM_DEVICE for their build but not have the int_gpios available to use the sensor's shutdown feature.

Quick fix, there is likely a better solution.